### PR TITLE
EvilHackerのアドミンボタン下のテキストを変更

### DIFF
--- a/SupplementalAUMod/Buttons.cs
+++ b/SupplementalAUMod/Buttons.cs
@@ -40,6 +40,7 @@ static class HudManagerStartPatch {
         evilHackerButton.skipSetCoolDown = true; // workaround
         // TODO: refactor refactor refactor
         evilHackerButton.sprite = EvilHacker.getButtonSprite();
+        evilHackerButton.text = EvilHacker.getButtonText();
         evilHackerButton.positionOffset = new Vector3(0, 2.0f, 0);
         evilHackerButton.positionTransform = true;
 

--- a/SupplementalAUMod/CustomButton.cs
+++ b/SupplementalAUMod/CustomButton.cs
@@ -21,6 +21,7 @@ public class CustomButton {
     public bool skipSetCoolDown = false;
     public float EffectDuration;
     public Sprite sprite;
+    public string text;
     public Vector3 positionOffset = new Vector3(0, 0, 0);
     public bool positionTransform = false;
     private HudManager hudManager;
@@ -141,6 +142,8 @@ public class CustomButton {
 
         if (sprite != null)
             actionButton.graphic.sprite = sprite;
+        if (text != null)
+            actionButton.OverrideText(text);
         if (hudManager.UseButton != null && positionTransform) {
             Vector3 pos = hudManager.UseButton.transform.localPosition;
             actionButton.transform.localPosition = pos + positionOffset;

--- a/SupplementalAUMod/Roles.cs
+++ b/SupplementalAUMod/Roles.cs
@@ -103,6 +103,7 @@ public static class Roles {
         public static Color color = Palette.ImpostorRed;
 
         private static Sprite buttonSprite;
+        private static string buttonText;
         public static Sprite getButtonSprite()
         {
             if (buttonSprite)
@@ -110,6 +111,13 @@ public static class Roles {
             UseButtonSettings button = FastDestroyableSingleton<HudManager>.Instance.UseButton.fastUseSettings[ImageNames.AirshipAdminButton];
             buttonSprite = button.Image;
             return buttonSprite;
+        }
+        public static string getButtonText()
+        {
+            if (buttonText != null)
+                return buttonText;
+            buttonText = FastDestroyableSingleton<TranslationController>.Instance.GetString(StringNames.Admin);
+            return buttonText;
         }
 
         public static void clearAndReload()


### PR DESCRIPTION
カスタムボタンのボタン下テキストを変更できるようにし，EvilHackerのアドミンマップボタン下のテキストを｢使用｣から｢管理室｣としました(日本語設定の場合)．
ゲーム内の翻訳をそのまま使用しているので設定によって言語が変わります．

不要でしたらCloseしていただければと思います
