### PR TITLE
会議画面の後ろを黒く覆い隠すように

### DIFF
--- a/SupplementalAUMod/Patches/MeetingHudPatch.cs
+++ b/SupplementalAUMod/Patches/MeetingHudPatch.cs
@@ -1,0 +1,39 @@
+using HarmonyLib;
+using UnityEngine;
+
+namespace AUMod.Patches
+{
+    [HarmonyPatch]
+    public static class MeetingHudPatch {
+        private static GameObject blackScreen;
+        public static GameObject getBlackScreen()
+        {
+            if (blackScreen)
+                return blackScreen;
+            var hudManager = FastDestroyableSingleton<HudManager>.Instance;
+            var spriteRenderer = Object.Instantiate(hudManager.FullScreen, hudManager.transform);
+            spriteRenderer.color = Color.black;
+            spriteRenderer.enabled = true;
+            blackScreen = spriteRenderer.gameObject;
+            blackScreen.transform.localPosition = new Vector3(0f, 0f, 10f);
+            blackScreen.SetActive(false);
+            return blackScreen;
+        }
+
+        [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.Start))]
+        public static class MeetingHudStartPatch {
+            public static void Postfix(MeetingHud __instance)
+            {
+                getBlackScreen().SetActive(true);
+            }
+        }
+
+        [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.OnDestroy))]
+        public static class MeetingHudOnDestroyPatch {
+            public static void Postfix(MeetingHud __instance)
+            {
+                getBlackScreen().SetActive(false);
+            }
+        }
+    }
+}

--- a/SupplementalAUMod/Patches/MeetingHudPatch.cs
+++ b/SupplementalAUMod/Patches/MeetingHudPatch.cs
@@ -15,7 +15,7 @@ namespace AUMod.Patches
             spriteRenderer.color = Color.black;
             spriteRenderer.enabled = true;
             blackScreen = spriteRenderer.gameObject;
-            blackScreen.transform.localPosition = new Vector3(0f, 0f, 10f);
+            blackScreen.transform.localPosition = MeetingHud.Instance.BlackBackground.transform.localPosition;
             blackScreen.SetActive(false);
             return blackScreen;
         }


### PR DESCRIPTION
会議開始の演出の合間に一瞬まわりが見えてしまう現象の対策です．
会議招集時に会議画面の後ろを黒い画面で覆い隠しています．
