### PR TITLE
タスクパネルのテキスト変更が反映されていない問題を修正

### DIFF
--- a/SupplementalAUMod/Patches/PlayerControlPatch.cs
+++ b/SupplementalAUMod/Patches/PlayerControlPatch.cs
@@ -155,8 +155,8 @@ namespace AUMod.Patches
                 string meetingInfoText = "";
                 if (p == PlayerControl.LocalPlayer) {
                     playerInfoText = $"{roleNames}";
-                    if (DestroyableSingleton<TaskPanelBehaviour>.InstanceExists) {
-                        TMPro.TextMeshPro tabText = DestroyableSingleton<TaskPanelBehaviour>.Instance.tab.transform.FindChild("TabText_TMP").GetComponent<TMPro.TextMeshPro>();
+                    if (DestroyableSingleton<HudManager>.InstanceExists) {
+                        TMPro.TextMeshPro tabText = DestroyableSingleton<HudManager>.Instance.TaskPanel.tab.transform.FindChild("TabText_TMP").GetComponent<TMPro.TextMeshPro>();
                         tabText.SetText($"Tasks {taskInfo}");
                     }
                     meetingInfoText = $"{roleNames} {taskInfo}".Trim();


### PR DESCRIPTION
本来，画面左上のタスクパネルの部分には`Tasks ({完了済タスク数}/{タスク総数})`と表記されるはずですが，12月のアップデート以来反映されていない状態でした．
その修正です．
