### PR TITLE
通信サボタージュ中は完了済タスク数の表示を隠すよう変更

### DIFF
--- a/SupplementalAUMod/Patches/PlayerControlPatch.cs
+++ b/SupplementalAUMod/Patches/PlayerControlPatch.cs
@@ -149,7 +149,8 @@ namespace AUMod.Patches
 
                 var (tasksCompleted, tasksTotal) = TasksHandler.taskInfo(p.Data);
                 string roleNames = String.Join(" ", RoleInfo.getRoleInfoForPlayer(p).Select(x => Helpers.cs(x.color, x.name)).ToArray());
-                string taskInfo = tasksTotal > 0 ? $"<color=#FAD934FF>({tasksCompleted}/{tasksTotal})</color>" : "";
+                var isComms = PlayerControl.LocalPlayer.myTasks.ToArray().Any(task => task.TaskType == TaskTypes.FixComms);
+                string taskInfo = tasksTotal > 0 ? $"<color=#FAD934FF>({(isComms ? "?" : tasksCompleted)}/{tasksTotal})</color>" : "";
 
                 string playerInfoText = "";
                 string meetingInfoText = "";


### PR DESCRIPTION
会議画面や画面左上に表示されるタスク数の表示が，コミュサボ中は`(?/10)`といった形になるよう変更しました．
11月以前と同様の仕様となります．
