### PR TITLE
非ホストがタスク数を計算しないことにより，常にタスクバーが表示されていた問題を修正

### DIFF
--- a/SupplementalAUMod/TasksHandler.cs
+++ b/SupplementalAUMod/TasksHandler.cs
@@ -43,8 +43,6 @@ public static class TasksHandler {
     private static class GameDataRecomputeTaskCountsPatch {
         private static bool Prefix(GameData __instance)
         {
-            if (!AmongUsClient.Instance.AmHost)
-                return false;
             __instance.TotalTasks = 0;
             __instance.CompletedTasks = 0;
             for (int i = 0; i < __instance.AllPlayers.Count; i++) {


### PR DESCRIPTION
タスクバーの表示が正しくない事象に代表される，`GameDataRecomputeTaskCountsPatch.Prefix()`で非ホストが何もせずに早期リターンしていたことに起因する問題を修正しました．

ゲーム本体でタスクバーを更新する`ProgressTracker.FixedUpdate()`では，タスクバーの更新や非表示を`GameData.Instance.TotalTasks > 0`が`true`の場合のみ行っていますが，この`GameData.Instance.TotalTasks`(以下`TotalTasks`)を更新する`GameData.RecomputeTaskCounts()`にあたる処理を非ホストが行っていないことにより，非ホストの`TotalTasks`が常に0となり，タスクバーの更新が行われない状態でした．

タスクバーに関してはあまり重大な問題ではないことは認識しておりますので，より優先度の高い別の問題に対処しているなど私の認識漏れがありましたらそちらを優先する形で対応いたします．
