### PR TITLE
キル能力を使い切ったSheriffがターゲットを設定しないよう変更

### DIFF
--- a/SupplementalAUMod/Patches/PlayerControlPatch.cs
+++ b/SupplementalAUMod/Patches/PlayerControlPatch.cs
@@ -103,7 +103,7 @@ namespace AUMod.Patches
 
         static void sheriffSetTarget()
         {
-            if (Sheriff.sheriff == null || Sheriff.sheriff != PlayerControl.LocalPlayer)
+            if (Sheriff.sheriff == null || Sheriff.sheriff != PlayerControl.LocalPlayer || Sheriff.remainingShots <= 0)
                 return;
             Sheriff.currentTarget = setTarget();
             setPlayerOutline(Sheriff.currentTarget, Sheriff.color);


### PR DESCRIPTION
キル能力を使い切ったSheriffがキルのターゲットを設定しないよう変更しました．
これにより，キル能力のないSheriffからはターゲットを示す黄色いアウトラインが見えなくなります．