### PR TITLE
はしご上のターゲットに対してのキルをブロック

### DIFF
--- a/SupplementalAUMod/Patches/PlayerControlPatch.cs
+++ b/SupplementalAUMod/Patches/PlayerControlPatch.cs
@@ -250,9 +250,10 @@ namespace AUMod.Patches
     public static class CheckMurderPatch {
         public static bool Prefix([HarmonyArgument(0)] PlayerControl target)
         {
-            if (!AmongUsClient.Instance.AmHost) return false;
-            // block bad kills
-            return !target.onLadder;
+            // prevent executing RpcMurderPlayer if the target player is on a ladder
+            if (AmongUsClient.Instance.AmHost && target != null && target.onLadder)
+                return false;
+            return true;
         }
     }
 }

--- a/SupplementalAUMod/Patches/PlayerControlPatch.cs
+++ b/SupplementalAUMod/Patches/PlayerControlPatch.cs
@@ -245,4 +245,14 @@ namespace AUMod.Patches
                 __instance.clearAllTasks();
         }
     }
+
+    [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.CheckMurder))]
+    public static class CheckMurderPatch {
+        public static bool Prefix([HarmonyArgument(0)] PlayerControl target)
+        {
+            if (!AmongUsClient.Instance.AmHost) return false;
+            // block bad kills
+            return !target.onLadder;
+        }
+    }
 }


### PR DESCRIPTION
ゲーム本体の`PlayerControl.CheckMurder()`では，キルターゲットの状態について

* ターゲットが既に死亡していないか
* ターゲットがベント内にいないか
* ターゲットが昇降機に乗っていないか

をチェックしていますが，これらにはしごのチェックが含まれていないため，はしご上のターゲットをキルしてしまうことによってキルしたインポスターが壁に埋まる事象が多発していました．
その対策として，はしごのチェックを追加しています．
