### PR TITLE
Revert CheckMuderPatch

### DIFF
--- a/SupplementalAUMod/Patches/PlayerControlPatch.cs
+++ b/SupplementalAUMod/Patches/PlayerControlPatch.cs
@@ -245,15 +245,4 @@ namespace AUMod.Patches
                 __instance.clearAllTasks();
         }
     }
-
-    [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.CheckMurder))]
-    public static class CheckMurderPatch {
-        public static bool Prefix([HarmonyArgument(0)] PlayerControl target)
-        {
-            // prevent executing RpcMurderPlayer if the target player is on a ladder
-            if (AmongUsClient.Instance.AmHost && target != null && target.onLadder)
-                return false;
-            return true;
-        }
-    }
 }


### PR DESCRIPTION
Due to the buggy management of `onLadder` by Among Us, CheckMurderPatch falsely rejects requests.
This patch reverts CheckMurderPatch to prevent this.

This patch is related to #24.
However, this patch does not fix all of bugs in #24 